### PR TITLE
fix go.mod typo that prevents this from being remotely installed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitgub.com/vinser/burnfix
+module github.com/vinser/burnfix
 
 go 1.20
 


### PR DESCRIPTION
When trying to run this:

```
go install github.com/vinser/burnfix@latest
```

It fails because the module is defined in `go.mod` as GITGUB.COM instead of GITHUB

This PR resolves the issue.